### PR TITLE
Hide the site parameter

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,7 +1,8 @@
 <script type="text/x-handlebars" data-template-name="components/google-search">
 <div>
   <form action='//www.baidu.com/s' id='google-search'>
-    <input type="text" name="wd" value="{{searchTerm}} site:{{siteUrl}}"> 
+    <input type="text" value="{{searchTerm}}">
+    <input type="text" name="wd" value="{{searchTerm}} site:{{siteUrl}}" type="hidden">
     <button class="btn btn-primary">Baidu</button>
   </form>
 </div>


### PR DESCRIPTION
For some reason the combination of the `q6` parameter (equivalent to `as_sitesearch`) does not work as it should together with the search terms. This workaround allows you to hide the site name from the search field and make the search work as it should on Baidu.